### PR TITLE
mtu changes for the docker runner

### DIFF
--- a/apps/templates/drone-runner-docker-app.yaml
+++ b/apps/templates/drone-runner-docker-app.yaml
@@ -45,6 +45,7 @@ spec:
           # https://docs.drone.io/server/reference/
           - {{ .Values.gitea.oAuthSecret }}
         env:
+          DRONE_RUNNER_NETWORK_OPTS: "com.docker.network.driver.mtu:{{ .Values.drone.docker.runner.mtu }}"
           DRONE_RPC_HOST: "drone:30980"
 
       # Optional Helm version to template with. If omitted it will fall back to look at the 'apiVersion' in Chart.yaml

--- a/apps/values.yaml
+++ b/apps/values.yaml
@@ -30,7 +30,7 @@ drone:
     runner:
       version: 0.3.0
       insecureRegistries: []
-      mtu: "1450"
+      mtu: "1410"
   # Drone Helm Chart settings
   server:
     # the chart version


### PR DESCRIPTION
change the default mtu value to 1410, which is the lowest I have seen in
instruqt

also set com.docker.network.driver.mtu via DRONE_RUNNER_NETWORK_OPTS so that
networks launched by the docker runner also have the appropriate mtu